### PR TITLE
Add basic iOS IP locator example

### DIFF
--- a/IPLocatorApp/ContentView.swift
+++ b/IPLocatorApp/ContentView.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+struct IPInfo: Decodable {
+    let query: String
+    let country: String
+    let regionName: String
+    let city: String
+}
+
+class IPService: ObservableObject {
+    @Published var info: IPInfo?
+    @Published var error: String?
+
+    func fetchIPInfo() async {
+        let url = URL(string: "https://ip-api.com/json")!
+        do {
+            let (data, _) = try await URLSession.shared.data(from: url)
+            let decoded = try JSONDecoder().decode(IPInfo.self, from: data)
+            await MainActor.run {
+                self.info = decoded
+            }
+        } catch {
+            await MainActor.run {
+                self.error = error.localizedDescription
+            }
+        }
+    }
+}
+
+struct ContentView: View {
+    @StateObject private var service = IPService()
+
+    var body: some View {
+        VStack(spacing: 20) {
+            if let info = service.info {
+                Text("IP: \(info.query)")
+                Text("Country: \(info.country)")
+                Text("Region: \(info.regionName)")
+                Text("City: \(info.city)")
+            } else if let error = service.error {
+                Text("Error: \(error)")
+            } else {
+                Text("Tap button to fetch IP info")
+            }
+            Button("Fetch IP Info") {
+                Task { await service.fetchIPInfo() }
+            }
+            .padding()
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/IPLocatorApp/IPLocatorApp.swift
+++ b/IPLocatorApp/IPLocatorApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct IPLocatorApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/IPLocatorApp/README.md
+++ b/IPLocatorApp/README.md
@@ -1,0 +1,10 @@
+# IPLocatorApp
+
+This is a very small SwiftUI example that fetches IP geolocation information using `ip-api.com`.
+
+## Building
+
+1. Open the folder in Xcode (`File` -> `Open` -> select `IPLocatorApp` directory).
+2. Build and run on an iOS device or simulator.
+
+The app displays your current IP address and location when you tap the **Fetch IP Info** button.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # chtgpt
+
+## IPLocatorApp
+This directory contains a simple iOS SwiftUI app that queries IP geolocation using the ip-api.com service.


### PR DESCRIPTION
## Summary
- add minimal SwiftUI project that shows IP geolocation using `ip-api.com`
- document the example project in README

## Testing
- `swiftc -parse IPLocatorApp/*.swift`

------
https://chatgpt.com/codex/tasks/task_e_684015ddf264832ba5ad2e51efa75ad9